### PR TITLE
docs: misc. Twitter accounts to follow/learn from

### DIFF
--- a/stage-0-getting-started.md
+++ b/stage-0-getting-started.md
@@ -57,3 +57,10 @@ Here are some starting points for learning about the Ethereum protocol.
    - Overview: https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/
    - Why Proof of Stake? (Vitalik Buterin): https://vitalik.ca/general/2020/11/06/pos2020.html
    - The Merge: https://ethereum.org/en/eth2/merge/
+
+### Thought Leaders on Twitter
+- Vitalik Buterin, [@VitalikButerin](https://twitter.com/VitalikButerin)
+- Tim Beiko, [@TimBeiko](https://twitter.com/TimBeiko)
+- Phil Daian, [@phildaian](https://twitter.com/phildaian)
+- Hasu, [@hasufl](https://twitter.com/hasufl)
+- Sam Sun [@samczsun](https://twitter.com/samczsun)


### PR DESCRIPTION
# Abstract
The following pull request is to extend the CDAP cohort Stage 0 "learning" documentation to include Twitter accounts.

# Motivation
To provide additional resources to help cohort members gain exposure to the Ethereum & the general crypto ecosystem. Twitter is a great resource for the most up-to-date "happenings" in the space, and it could be extremely beneficial for cohort members (especially, non-crypto natives) to start following thought leaders & accelerate learning. This list is non-exhaustive and meant to be a starting point / idea for this pull request. For example, it could be further extended into overarching categories wherein the Twitter account, typically, posts/researches about.

# Example
- @phildaian for MEV research
- @TimBeiko for ETH development updates
- @VitalikButerin because it's Vitalik

# Rationale
Twitter resources help ensure cohort members are exploring the ecosystem in a way that provides creativity for the Stage 1 discovery phase of the program, which should be inclusive of "live" resources (e.g., more frequent / less structured thoughts than an EIP).